### PR TITLE
cambios config.js para evitar repetir datos al cargar seeders

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -4,10 +4,14 @@ module.exports = {
     "development": {
         "username": process.env.DB_USER,
         "password": process.env.DB_PASSWORD,
-        "database":  process.env.DB_NAME,
+        "database": process.env.DB_NAME,
         "host": process.env.DB_HOST,
         "port": process.env.DB_PORT,
-        "dialect": "mysql"
+        "dialect": "mysql",
+
+        "seederStorage": "sequelize",
+        "seederStoragePath": "sequelizeData",
+
     },
     "test": {
         "username": process.env.DB_USER,
@@ -23,9 +27,9 @@ module.exports = {
         "host": process.env.DB_HOST,
         "dialect": "mysql"
     },
-    "aws": { 
-"accessKeyId": process.env.ACCESS_KEY_ID,
-"secretAccessKey": process.env.SECRET_ACCESS_KEY,
-"s3BucketName": process.env.S3_BUCKET_NAME
+    "aws": {
+        "accessKeyId": process.env.ACCESS_KEY_ID,
+        "secretAccessKey": process.env.SECRET_ACCESS_KEY,
+        "s3BucketName": process.env.S3_BUCKET_NAME
     }
 }


### PR DESCRIPTION
Cambios en configuración archivo config.js para no repetir datos al cargar seeders. Al descargar estos cambios se deberá eliminar los datos de la base de datos tanto seeders como migraciones y volver a ejecutar nxp sequelize-cli db:migrate y npx sequelize-cli db:seed:all. Este ultimo comando además de cargar los datos de los seeders a la db, creara una tabla denominada "sequelizedata" donde se almacenaran los nombres de los seeders que ya fueron cargados. En caso de que se desee cargar datos nuevos u otros seeders, el comando npx ... buscará primero en esta tabla para cotejar si existe el seeders que queremos agregar y de encontrarlo cotejará que no haya datos duplicados, pasando ambas validaciones cargará el seeders