### PR TITLE
modified categories test post create news

### DIFF
--- a/tests/categories.test.js
+++ b/tests/categories.test.js
@@ -46,8 +46,8 @@ let idNotFound='a';
     .send({name:"NewsforCategoryTest", image:"https://NewsforCategoryTest.com/600/92c952", type:"news",content: "NewsforCategoryTest", categoryId:10, deletdAt:null}) 
     expect(response.status).to.eql(201);
     expect(response.body).to.be.an('object')
-    idNews=response.body.data.id
-    newsCatgoryId=response.body.data.categoryId
+    idNews=response.body.id
+    newsCatgoryId=response.body.categoryId
   });
 
   // CREATE CATEGORY


### PR DESCRIPTION
modified categories test post create news, because news started using the base controller and changed the response format

[https://github.com/alkemyTech/OT224-server/tree/OT224-categoriesTest](url)